### PR TITLE
Remove the country specific from language code.

### DIFF
--- a/translations/lxqt-sudo_el.ts
+++ b/translations/lxqt-sudo_el.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="el_GR">
+<TS version="2.1" language="el">
 <context>
     <name>PasswordDialog</name>
     <message>


### PR DESCRIPTION
There is no need to have a country specific code for Greek translations
See also: https://github.com/lxde/lximage-qt/pull/32